### PR TITLE
Travis CI build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,3 @@
+language: scala
+scala:
+   - 2.9.2

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+sudo: required
+
 language: scala
 
 jdk:
@@ -7,4 +9,4 @@ scala:
    - 2.9.2
    
 before_install:
-  - perl -npi -e 's/^( *addSbt (warn|info).*)/#$1/g' /usr/local/bin/sbt
+  - sudo perl -npi -e 's/^( *addSbt (warn|info).*)/#$1/g' /usr/local/bin/sbt

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,10 @@
 language: scala
+
 jdk:
   - oraclejdk7
+
 scala:
    - 2.9.2
+   
+before_install:
+  - perl -npi -e 's/^( *addSbt (warn|info).*)/#$1/g' /usr/local/bin/sbt

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
 language: scala
+jdk:
+  - oraclejdk7
 scala:
    - 2.9.2


### PR DESCRIPTION
Because the sbt-extras that Travis CI uses doesn't currently work on sbt 0.11, we have to enable sudo so we can modify it.