### PR TITLE
Properly report a queue age with no gets

### DIFF
--- a/src/test/scala/net/lag/kestrel/PersistentQueueSpec.scala
+++ b/src/test/scala/net/lag/kestrel/PersistentQueueSpec.scala
@@ -995,7 +995,6 @@ class PersistentQueueSpec extends SpecificationWithJUnit
           q.setup
           put(q, 128, 0)
           put(q, 128, 0)
-          q.remove()
 
           time.advance(10.milliseconds)
           q.currentAge mustEqual 10.milliseconds


### PR DESCRIPTION
Currently, reported queue age is bogus until the first GET happens on a queue.

This change will `peek()` for the `addTime` of the first item in the queue if there have not been any GETs to it.