### PR TITLE
Check open transactions before expiring queues

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -19,7 +19,7 @@ object Kestrel extends Build {
     version := "2.4.8-SNAPSHOT",
     scalaVersion := "2.9.2",
 
-    resolvers += "Twitter Repository" at "http://maven.twttr.com",
+    resolvers := Seq(DefaultMavenRepository, "Twitter Repository" at "http://maven.twttr.com"),
 
     // time-based tests cannot be run in parallel
     logBuffered in Test := false,

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -19,6 +19,8 @@ object Kestrel extends Build {
     version := "2.4.8-SNAPSHOT",
     scalaVersion := "2.9.2",
 
+    resolvers += "Twitter Repository" at "http://maven.twttr.com",
+
     // time-based tests cannot be run in parallel
     logBuffered in Test := false,
     parallelExecution in Test := false,

--- a/src/main/scala/net/lag/kestrel/PersistentQueue.scala
+++ b/src/main/scala/net/lag/kestrel/PersistentQueue.scala
@@ -246,7 +246,7 @@ class PersistentQueue(val name: String, persistencePath: PersistentStreamContain
    */
   def isReadyForExpiration: Boolean = {
     // Don't even bother if the maxQueueAge is None
-    if (config.maxQueueAge.isDefined && queue.isEmpty) {
+    if (config.maxQueueAge.isDefined && queue.isEmpty && openTransactions.isEmpty) {
       val lastOperationTime = if (_currentAge == null) _createTime else _currentAge
 
       Time.now > lastOperationTime + config.maxQueueAge.get


### PR DESCRIPTION
We had a queue get deleted this morning and it appeared to have open transactions:

```
Aug 29 11:27:21 pt01mq04 kestrel.log: INF [20170829-03:27:21.002] kestrel: Queue raw_event_07 deleted by <unknown>
Aug 29 11:27:21 pt01mq04 kestrel.log: INF [20170829-03:27:21.003] kestrel: Expired queue raw_event_07
Aug 29 11:27:21 pt01mq04 kestrel.log: INF [20170829-03:27:21.003] kestrel: Setting up queue raw_event_07: maxItems=2147483647 maxSize=9223372036854775807.bytes maxItemSize=9223372036854775807.bytes maxAge=None defaultJournalSize=16777216.bytes maxMemorySize=134217728.bytes maxJournalSize=1073741824.bytes minJournalCompactDelay=Some(1.minutes) discardOldWhenFull=false keepJournal=true syncJournal=5.seconds expireToQueue=None maxExpireSweep=2147483647 fanoutOnly=false maxQueueAge=Some(1.hours) enableTrace=false disableAggressiveRewrites=false, openTransactionTimeout=None, whiteListClientIdForDequeue=None, whiteListClientIdForEnqueue=None (via Session 45936346 Client <function0>)
Aug 29 11:27:21 pt01mq04 kestrel.log: INF [20170829-03:27:21.003] kestrel: Replaying transaction journal for 'raw_event_07'
Aug 29 11:27:21 pt01mq04 kestrel.log: INF [20170829-03:27:21.003] kestrel: Replaying 'raw_event_07' file raw_event_07
Aug 29 11:27:21 pt01mq04 kestrel.log: INF [20170829-03:27:21.003] kestrel: No transaction journal for 'raw_event_07'; starting with empty queue.
Aug 29 11:27:21 pt01mq04 kestrel.log: INF [20170829-03:27:21.003] kestrel: Finished scanning the transaction journal for 'raw_event_07' (0 items, 0 bytes) xid=0, removes=0
Aug 29 11:27:21 pt01mq04 kestrel.log: INF [20170829-03:27:21.004] kestrel: Finished replaying the transaction journal for 'raw_event_07' in 0 milliseconds
Aug 29 11:27:21 pt01mq04 kestrel.log: WAR [20170829-03:27:21.010] kestrel: Queue raw_event_07: Trying to abort a transaction (214679686) that was not open
Aug 29 11:27:21 pt01mq03 kestrel.log: INF [20170829-03:27:21.015] kestrel: Rewriting journal file for 'raw_event_06' (qsize=0)
Aug 29 11:27:21 pt01mq04 kestrel.log: WAR [20170829-03:27:21.019] kestrel: Queue raw_event_07: Trying to commit a transaction (214679673) that was not open
Aug 29 11:27:21 pt01mq04 kestrel.log: WAR [20170829-03:27:21.034] kestrel: Queue raw_event_07: Trying to commit a transaction (214679681) that was not open
Aug 29 11:27:21 pt01mq01 kestrel.log: INF [20170829-03:27:21.058] kestrel: Rewriting journal file for 'raw_event_05' (qsize=0)
```

`#isReadyForExpiration` only checks `queue.isEmpty` [Items are removed from `queue`](https://github.com/papertrail/kestrel/blob/1345ca5421e00d916acb4692d756615f4524baa1/src/main/scala/net/lag/kestrel/PersistentQueue.scala#L866-L885) when they're handed out to a worker and waiting to be processed. In order to reliably check if a queue is empty, `openTransactions` needs to be consulted as well. [We've had to account for this in haneda.](https://github.com/sevenscale/haneda/blob/062daae498fa82251e1bb40a77cd6c8a39a65fc5/src/main/java/com/papertrailapp/haneda/queue/DurableKestrelQueue.java#L325)

I'm working on tests and then this will be ready.