### PR TITLE
Switch to https in maven repository URL

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,11 +3,11 @@ sudo: required
 language: scala
 
 jdk:
-  - oraclejdk7
+  - openjdk7
 
 scala:
    - 2.9.2
-   
+
 before_install:
   - sudo perl -npi -e 's/^( *addSbt (warn|info).*)/#$1/g' /usr/local/bin/sbt
 

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -19,7 +19,7 @@ object Kestrel extends Build {
     version := "2.4.8-SNAPSHOT",
     scalaVersion := "2.9.2",
 
-    resolvers := Seq(DefaultMavenRepository, "Twitter Repository" at "http://maven.twttr.com"),
+    resolvers := Seq(DefaultMavenRepository, "Twitter Repository" at "https://maven.twttr.com"),
 
     // time-based tests cannot be run in parallel
     logBuffered in Test := false,


### PR DESCRIPTION
Tried building kestrel and bumped in to a problem with unresolved dependencies related to `http://maven.twttr.com` in `project/Build.scala`.

After changing the twitter URL from `http` to `https` the build finished successfully.

(Using sbt 0.13.17, Scala 2.9.2, Java 1.7.0)

### After (with `https`)

```
$ sbt clean update package-dist
...
[info] Building kestrel-769b608e.zip from 86 files.
[success] Total time: 83 s, completed Feb 27, 2018 4:02:00 PM
```

### Before (with `http`)

```
$ sbt clean update package-dist
...
[warn] 	::::::::::::::::::::::::::::::::::::::::::::::
[warn] 	::          UNRESOLVED DEPENDENCIES         ::
[warn] 	::::::::::::::::::::::::::::::::::::::::::::::
[warn] 	:: com.twitter#ostrich;8.2.9: not found
[warn] 	:: com.twitter#naggati_2.9.2;4.1.0: not found
[warn] 	:: com.twitter#finagle-core;6.4.1: not found
[warn] 	:: com.twitter#finagle-ostrich4;6.4.1: not found
[warn] 	:: com.twitter#finagle-thrift;6.4.1: not found
[warn] 	:: com.twitter.common.zookeeper#server-set;1.0.16: not found
[warn] 	::::::::::::::::::::::::::::::::::::::::::::::
sbt.ResolveException: unresolved dependency: com.twitter#ostrich;8.2.9: not found
unresolved dependency: com.twitter#naggati_2.9.2;4.1.0: not found
unresolved dependency: com.twitter#finagle-core;6.4.1: not found
unresolved dependency: com.twitter#finagle-ostrich4;6.4.1: not found
unresolved dependency: com.twitter#finagle-thrift;6.4.1: not found
unresolved dependency: com.twitter.common.zookeeper#server-set;1.0.16: not found
	at sbt.IvyActions$.sbt$IvyActions$$resolve(IvyActions.scala:214)
	at sbt.IvyActions$$anonfun$update$1.apply(IvyActions.scala:122)
	at sbt.IvyActions$$anonfun$update$1.apply(IvyActions.scala:121)
	at sbt.IvySbt$Module$$anonfun$withModule$1.apply(Ivy.scala:117)
	at sbt.IvySbt$Module$$anonfun$withModule$1.apply(Ivy.scala:117)
	at sbt.IvySbt$$anonfun$withIvy$1.apply(Ivy.scala:105)
	at sbt.IvySbt.liftedTree1$1(Ivy.scala:52)
	at sbt.IvySbt.action$1(Ivy.scala:52)
	at sbt.IvySbt$$anon$3.call(Ivy.scala:61)
	at xsbt.boot.Locks$GlobalLock.withChannel$1(Locks.scala:93)
	at xsbt.boot.Locks$GlobalLock.xsbt$boot$Locks$GlobalLock$$withChannelRetries$1(Locks.scala:78)
	at xsbt.boot.Locks$GlobalLock$$anonfun$withFileLock$1.apply(Locks.scala:97)
	at xsbt.boot.Using$.withResource(Using.scala:10)
	at xsbt.boot.Using$.apply(Using.scala:9)
	at xsbt.boot.Locks$GlobalLock.ignoringDeadlockAvoided(Locks.scala:58)
	at xsbt.boot.Locks$GlobalLock.withLock(Locks.scala:48)
	at xsbt.boot.Locks$.apply0(Locks.scala:31)
	at xsbt.boot.Locks$.apply(Locks.scala:28)
	at sbt.IvySbt.withDefaultLogger(Ivy.scala:61)
	at sbt.IvySbt.withIvy(Ivy.scala:102)
	at sbt.IvySbt.withIvy(Ivy.scala:98)
	at sbt.IvySbt$Module.withModule(Ivy.scala:117)
	at sbt.IvyActions$.update(IvyActions.scala:121)
	at sbt.Classpaths$$anonfun$work$1$1.apply(Defaults.scala:955)
	at sbt.Classpaths$$anonfun$work$1$1.apply(Defaults.scala:953)
	at sbt.Classpaths$$anonfun$doWork$1$1$$anonfun$58.apply(Defaults.scala:976)
	at sbt.Classpaths$$anonfun$doWork$1$1$$anonfun$58.apply(Defaults.scala:974)
	at sbt.Tracked$$anonfun$lastOutput$1.apply(Tracked.scala:35)
	at sbt.Classpaths$$anonfun$doWork$1$1.apply(Defaults.scala:978)
	at sbt.Classpaths$$anonfun$doWork$1$1.apply(Defaults.scala:973)
	at sbt.Tracked$$anonfun$inputChanged$1.apply(Tracked.scala:45)
	at sbt.Classpaths$.cachedUpdate(Defaults.scala:981)
	at sbt.Classpaths$$anonfun$47.apply(Defaults.scala:858)
	at sbt.Classpaths$$anonfun$47.apply(Defaults.scala:855)
	at sbt.Scoped$$anonfun$hf10$1.apply(Structure.scala:586)
	at sbt.Scoped$$anonfun$hf10$1.apply(Structure.scala:586)
	at scala.Function1$$anonfun$compose$1.apply(Function1.scala:49)
	at sbt.Scoped$Reduced$$anonfun$combine$1$$anonfun$apply$12.apply(Structure.scala:311)
	at sbt.Scoped$Reduced$$anonfun$combine$1$$anonfun$apply$12.apply(Structure.scala:311)
	at sbt.$tilde$greater$$anonfun$$u2219$1.apply(TypeFunctions.scala:41)
	at sbt.std.Transform$$anon$5.work(System.scala:71)
	at sbt.Execute$$anonfun$submit$1$$anonfun$apply$1.apply(Execute.scala:232)
	at sbt.Execute$$anonfun$submit$1$$anonfun$apply$1.apply(Execute.scala:232)
	at sbt.ErrorHandling$.wideConvert(ErrorHandling.scala:18)
	at sbt.Execute.work(Execute.scala:238)
	at sbt.Execute$$anonfun$submit$1.apply(Execute.scala:232)
	at sbt.Execute$$anonfun$submit$1.apply(Execute.scala:232)
	at sbt.ConcurrentRestrictions$$anon$4$$anonfun$1.apply(ConcurrentRestrictions.scala:160)
	at sbt.CompletionService$$anon$2.call(CompletionService.scala:30)
	at java.util.concurrent.FutureTask.run(FutureTask.java:262)
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:471)
	at java.util.concurrent.FutureTask.run(FutureTask.java:262)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1145)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:615)
	at java.lang.Thread.run(Thread.java:744)
[error] (*:update) sbt.ResolveException: unresolved dependency: com.twitter#ostrich;8.2.9: not found
[error] unresolved dependency: com.twitter#naggati_2.9.2;4.1.0: not found
[error] unresolved dependency: com.twitter#finagle-core;6.4.1: not found
[error] unresolved dependency: com.twitter#finagle-ostrich4;6.4.1: not found
[error] unresolved dependency: com.twitter#finagle-thrift;6.4.1: not found
[error] unresolved dependency: com.twitter.common.zookeeper#server-set;1.0.16: not found
[error] Total time: 7 s, completed Feb 27, 2018 3:54:50 PM
```